### PR TITLE
Add static def to all inline functions to fix linking errors

### DIFF
--- a/src/data.c
+++ b/src/data.c
@@ -78,7 +78,7 @@ uint32_t data_get_id( ST_CFG *st )
 
 
 
-inline DHASH *data_find_path( DHASH *list, uint32_t hval, char *path, int len )
+static inline DHASH *data_find_path( DHASH *list, uint32_t hval, char *path, int len )
 {
 	DHASH *h;
 
@@ -128,7 +128,7 @@ DHASH *data_locate( char *path, int len, int type )
 
 
 
-inline DHASH *data_get_dhash( char *path, int len, ST_CFG *c )
+static inline DHASH *data_get_dhash( char *path, int len, ST_CFG *c )
 {
 	uint32_t hval, idx;
 	DHASH *d;

--- a/src/io.c
+++ b/src/io.c
@@ -199,7 +199,7 @@ int io_connect( TARGET *t )
 
 
 
-inline void io_decr_buf( IOBUF *buf )
+static inline void io_decr_buf( IOBUF *buf )
 {
 	int free_it = 0;
 

--- a/src/mem.c
+++ b/src/mem.c
@@ -50,7 +50,7 @@ void __mtype_alloc_free( MTYPE *mt, int count )
 }
 
 
-inline void *__mtype_new( MTYPE *mt )
+static inline void *__mtype_new( MTYPE *mt )
 {
 	MTBLANK *b;
 
@@ -72,7 +72,7 @@ inline void *__mtype_new( MTYPE *mt )
 }
 
 
-inline void *__mtype_new_list( MTYPE *mt, int count )
+static inline void *__mtype_new_list( MTYPE *mt, int count )
 {
 	MTBLANK *top, *end;
 	int i;
@@ -105,7 +105,7 @@ inline void *__mtype_new_list( MTYPE *mt, int count )
 
 
 
-inline void __mtype_free( MTYPE *mt, void *p )
+static inline void __mtype_free( MTYPE *mt, void *p )
 {
 	MTBLANK *b = (MTBLANK *) p;
 
@@ -119,7 +119,7 @@ inline void __mtype_free( MTYPE *mt, void *p )
 }
 
 
-inline void __mtype_free_list( MTYPE *mt, int count, void *first, void *last )
+static inline void __mtype_free_list( MTYPE *mt, int count, void *first, void *last )
 {
 	MTBLANK *l = (MTBLANK *) last;
 

--- a/src/stats.c
+++ b/src/stats.c
@@ -18,7 +18,7 @@ const char *stats_type_names[STATS_TYPE_MAX] =
 
 
 
-inline int cmp_floats( const void *p1, const void *p2 )
+static inline int cmp_floats( const void *p1, const void *p2 )
 {
 	float *f1, *f2;
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -318,7 +318,7 @@ void pidfile_remove( void )
 // an implementation of Kaham Summation
 // https://en.wikipedia.org/wiki/Kahan_summation_algorithm
 // useful to avoid floating point errors
-inline void kahan_sum( float val, float *sum, float *low )
+static inline void kahan_sum( float val, float *sum, float *low )
 {
 	float y, t;
 


### PR DESCRIPTION
This fix intends to resolve the following error:

```
ahodgen@Europa:~/Documents/c/ministry$ make clean
make[1]: Entering directory '/home/ahodgen/Documents/c/ministry/src'
make[1]: Leaving directory '/home/ahodgen/Documents/c/ministry/src'
done.
ahodgen@Europa:~/Documents/c/ministry$ gcc --version
gcc (Ubuntu 5.2.1-22ubuntu2) 5.2.1 20151010
Copyright (C) 2015 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

ahodgen@Europa:~/Documents/c/ministry$ make
make[1]: Entering directory '/home/ahodgen/Documents/c/ministry/src'
/usr/bin/gcc -Wall -Wshadow -pthread -I.    -c -o utils.o utils.c
/usr/bin/gcc -Wall -Wshadow -pthread -I.    -c -o log.o log.c
/usr/bin/gcc -Wall -Wshadow -pthread -I.    -c -o loop.o loop.c
/usr/bin/gcc -Wall -Wshadow -pthread -I.    -c -o thread.o thread.c
/usr/bin/gcc -Wall -Wshadow -pthread -I.    -c -o mem.o mem.c
/usr/bin/gcc -Wall -Wshadow -pthread -I.    -c -o gc.o gc.c
/usr/bin/gcc -Wall -Wshadow -pthread -I.    -c -o net.o net.c
/usr/bin/gcc -Wall -Wshadow -pthread -I.    -c -o io.o io.c
/usr/bin/gcc -Wall -Wshadow -pthread -I.    -c -o data.o data.c
/usr/bin/gcc -Wall -Wshadow -pthread -I.    -c -o synth.o synth.c
/usr/bin/gcc -Wall -Wshadow -pthread -I.    -c -o stats.o stats.c
/usr/bin/gcc -Wall -Wshadow -pthread -I.    -c -o config.o config.c
/usr/bin/gcc -Wall -Wshadow -pthread -I.    -c -o main.o main.c
/usr/bin/gcc -Wall -Wshadow -o ministry -pthread -I.  -lm utils.o log.o loop.o thread.o mem.o gc.o net.o io.o data.o synth.o stats.o config.o main.o
utils.o: In function `kahan_summation':
utils.c:(.text+0x8fd): undefined reference to `kahan_sum'
mem.o: In function `mem_new_host':
mem.c:(.text+0xee): undefined reference to `__mtype_new'
mem.o: In function `mem_free_host':
mem.c:(.text+0x249): undefined reference to `__mtype_free'
mem.o: In function `mem_new_point':
mem.c:(.text+0x269): undefined reference to `__mtype_new'
mem.o: In function `mem_free_point':
mem.c:(.text+0x2c9): undefined reference to `__mtype_free'
mem.o: In function `mem_free_point_list':
mem.c:(.text+0x360): undefined reference to `__mtype_free_list'
mem.o: In function `mem_new_dhash':
mem.c:(.text+0x38c): undefined reference to `__mtype_new'
mem.o: In function `mem_free_dhash':
mem.c:(.text+0x504): undefined reference to `__mtype_free'
mem.o: In function `mem_free_dhash_list':
mem.c:(.text+0x631): undefined reference to `__mtype_free_list'
mem.o: In function `mem_new_iolist':
mem.c:(.text+0x662): undefined reference to `__mtype_new'
mem.o: In function `mem_free_iolist':
mem.c:(.text+0x6cf): undefined reference to `__mtype_free'
mem.o: In function `mem_free_iolist_list':
mem.c:(.text+0x773): undefined reference to `__mtype_free_list'
mem.o: In function `mem_new_buf':
mem.c:(.text+0x798): undefined reference to `__mtype_new'
mem.o: In function `mem_free_buf':
mem.c:(.text+0x90c): undefined reference to `__mtype_free'
mem.o: In function `mem_free_buf_list':
mem.c:(.text+0x9e0): undefined reference to `__mtype_free_list'
io.o: In function `io_buf_send':
io.c:(.text+0x805): undefined reference to `io_decr_buf'
io.o: In function `io_send_loop':
io.c:(.text+0xb5b): undefined reference to `io_decr_buf'
data.o: In function `data_locate':
data.c:(.text+0x25b): undefined reference to `data_find_path'
data.o: In function `data_point_gauge':
data.c:(.text+0x2d8): undefined reference to `data_get_dhash'
data.o: In function `data_point_adder':
data.c:(.text+0x3f1): undefined reference to `data_get_dhash'
data.o: In function `data_point_stats':
data.c:(.text+0x4cf): undefined reference to `data_get_dhash'
stats.o: In function `stats_report_one':
stats.c:(.text+0x1ec): undefined reference to `cmp_floats'
collect2: error: ld returned 1 exit status
Makefile:34: recipe for target 'ministry' failed
make[1]: *** [ministry] Error 1
make[1]: Leaving directory '/home/ahodgen/Documents/c/ministry/src'
Makefile:32: recipe for target 'code' failed
make: *** [code] Error 2
```

There may also be benefit to declare all none exposed functions static.
