### PR TITLE
Accept failure

### DIFF
--- a/src/data.c
+++ b/src/data.c
@@ -640,8 +640,13 @@ void *data_loop_tcp( void *arg )
 		// go get that then
 		if( p.revents & POLL_EVENTS )
 		{
-			if( ( h = net_get_host( p.fd, n->type ) ) )
-				thread_throw( data_connection, h );
+			if( !( h = net_get_host( p.fd, n->type ) ) )
+			{
+                            // Accept failure, ip check failure, or unable to allocate new host
+                            debug( "net_get_host failure, breaking out of run loop: %s", Err );
+                            break;
+			}
+			thread_throw( data_connection, h );
 		}
 	}
 

--- a/src/log.h
+++ b/src/log.h
@@ -51,7 +51,7 @@ LOG_CTL *log_config_defaults( void );
 int log_config_line( AVP *av );
 
 
-#define LLFLF( l, f, ... )		log_line( LOG_LEVEL_##l, __FILE__, __LINE__, __FUNCTION__, f, ## __VA_ARGS__ )
+#define LLFLF( l, f, ... )		log_line( LOG_LEVEL_##l, __FILE__, __LINE__, __func__, f, ## __VA_ARGS__ )
 #define LLNZN( l, f, ... )		log_line( LOG_LEVEL_##l,     NULL,        0,         NULL, f, ## __VA_ARGS__ )
 
 #define fatal( fmt, ... )		LLFLF( FATAL,  fmt, ## __VA_ARGS__ )


### PR DESCRIPTION
net_get_host may fail, for example due to accept failure from too many open files.

This intends to kill that specific TCP socket / thread in that situation.

Also, **func** is a c standard, where **FUNCTION** is a GCC extension kept for backwards compatibility.
